### PR TITLE
Add Christophe Bornet

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ People in the community actively talking about API Specifications (for example, 
 - **Arnaud Lauret** - [arno_di_loreto](https://twitter.com/arno_di_loreto)
 - **Bruno Pedro** - [bpedro](https://twitter.com/bpedro)
 - **Chris Williams** - [Scampiuk](https://twitter.com/Scampiuk)
+- **Christophe Bornet** - [cbornet_](https://twitter.com/cbornet_)
 - **Erik Wilde** - [dret](https://twitter.com/dret)
 - **Ivan Goncharov** - [e1goncharov](https://twitter.com/e1goncharov)
 - **Jason Harmon** - [jharmn](https://twitter.com/jharmn)


### PR DESCRIPTION
Adding me to the list if I'm worthy :smiley: 
- co-founder of OpenAPI-generator
- created [OHM](https://dev.to/cbornet/ohm-the-mediatype-for-rest-hateoas-powered-by-openapi-2aba), a mediatype for HATEOAS based on OpenAPI
- [JHipster](https://www.jhipster.tech/team/)'s OpenAPI stream lead